### PR TITLE
fixing up the docker env

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,42 +1,41 @@
-#FROM ubuntu:latest
-# For prodcution
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
+FROM python:3.8-slim
+ARG uid
+ARG DEBIAN_FRONTEND=noninteractive
+# Install dependencies
+RUN apt-get update\
+    && apt-get -y upgrade\
+    # Stupid base image bug https://stackoverflow.com/a/58503437
+    && mkdir -p /usr/share/man/man1\
+    && apt-get -y --no-install-recommends install openjdk-11-jre-headless\
+    && apt-get clean all\
+    && rm -rf /var/lib/apt/lists/
+
+# the entire magic of the tiangolo containers, without the risk
+## START
+RUN python -m pip install --no-cache-dir "uvicorn[standard]" gunicorn fastapi
+
+COPY ./gunicorn_conf.py /app/gunicorn.conf.py
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+COPY ./start-reload.sh /start-reload.sh
+RUN chmod +x /start-reload.sh
+## END
 
 # Set working directory
 WORKDIR /app
-RUN mkdir /app/data
+RUN mkdir /app/data && mkdir /app/log
+RUN chown $uid /app/data && chown $uid /app/log
 
 # Add app to Docker
 COPY . /app
 
-ARG DEBIAN_FRONTEND=noninteractive
-
 # Install dependencies
-RUN apt-get update
-RUN apt-get -y upgrade 
+RUN python -m pip install --no-cache-dir --upgrade -r requirements.txt 
 
-RUN apt-get -y install python3 \
-    python3-pip 
+USER "$uid"
 
-RUN apt-get -y install gfortran \
-    gcc \
-    build-essential \
-    zlib1g-dev \
-    wget \
-    unzip \
-    cmake \
-    python3-dev \
-    libblas-dev \
-    liblapack-dev \
-    libatlas-base-dev \
-    libc-dev \
-    openjdk-11-jdk 
 
-# Install dependencies
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade pip setuptools wheel
-RUN pip3 install --upgrade -r requirements.txt 
-
-EXPOSE 8080
 # Run FastAPI service
-#CMD python3 main.py --reload
+CMD ["/start.sh"]

--- a/api/gunicorn_conf.py
+++ b/api/gunicorn_conf.py
@@ -1,0 +1,67 @@
+import json
+import multiprocessing
+import os
+
+workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
+max_workers_str = os.getenv("MAX_WORKERS")
+use_max_workers = None
+if max_workers_str:
+    use_max_workers = int(max_workers_str)
+web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
+
+host = os.getenv("HOST", "0.0.0.0")
+port = os.getenv("PORT", "8080")
+bind_env = os.getenv("BIND", None)
+use_loglevel = os.getenv("LOG_LEVEL", "info")
+if bind_env:
+    use_bind = bind_env
+else:
+    use_bind = f"{host}:{port}"
+
+cores = multiprocessing.cpu_count()
+workers_per_core = float(workers_per_core_str)
+default_web_concurrency = workers_per_core * cores
+if web_concurrency_str:
+    web_concurrency = int(web_concurrency_str)
+    assert web_concurrency > 0
+else:
+    web_concurrency = max(int(default_web_concurrency), 2)
+    if use_max_workers:
+        web_concurrency = min(web_concurrency, use_max_workers)
+accesslog_var = os.getenv("ACCESS_LOG", "-")
+use_accesslog = accesslog_var or None
+errorlog_var = os.getenv("ERROR_LOG", "-")
+use_errorlog = errorlog_var or None
+graceful_timeout_str = os.getenv("GRACEFUL_TIMEOUT", "120")
+timeout_str = os.getenv("TIMEOUT", "120")
+keepalive_str = os.getenv("KEEP_ALIVE", "5")
+
+# Gunicorn config variables
+loglevel = use_loglevel
+workers = web_concurrency
+bind = use_bind
+errorlog = use_errorlog
+worker_tmp_dir = "/dev/shm"
+accesslog = use_accesslog
+graceful_timeout = int(graceful_timeout_str)
+timeout = int(timeout_str)
+keepalive = int(keepalive_str)
+
+
+# For debugging and testing
+log_data = {
+    "loglevel": loglevel,
+    "workers": workers,
+    "bind": bind,
+    "graceful_timeout": graceful_timeout,
+    "timeout": timeout,
+    "keepalive": keepalive,
+    "errorlog": errorlog,
+    "accesslog": accesslog,
+    # Additional, non-gunicorn variables
+    "workers_per_core": workers_per_core,
+    "use_max_workers": use_max_workers,
+    "host": host,
+    "port": port,
+}
+print(json.dumps(log_data))

--- a/api/main.py
+++ b/api/main.py
@@ -82,7 +82,7 @@ fastapi_logger.info(json.dumps(startMsg))
 async def startup():
     with open("conf.yaml", "r") as stream:
         conf = yaml.safe_load(stream)
-    host = conf["redis"][0]
+    host = os.getenv("REDIS_SERVER", conf["redis"][0])
     redis = await aioredis.create_redis_pool(f"redis://{host}")
     FastAPILimiter.init(redis)
 

--- a/api/main.py
+++ b/api/main.py
@@ -211,8 +211,8 @@ async def extract(request: Request, pdf: UploadFile = File(...)):
     return a JSON of extracted standards that are embedded within the SoW."""
     # filepath = save_upload_file_tmp(pdf)
     file_location = f"{pdf.filename}"
-    with open(file_location, "wb+") as file_object:
-        shutil.copyfileobj(pdf.file, file_object)
+    # with open(file_location, "wb+") as file_object:
+    #    shutil.copyfileobj(pdf.file, file_object)
     print({"info": f"file '{pdf.filename}' saved at '{file_location}'"})
     text = extract_prep.parse_text(file_location)
     refs = find_standard_ref(text)

--- a/api/start-reload.sh
+++ b/api/start-reload.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-8080}
+LOG_LEVEL=${LOG_LEVEL:-info}
+
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Uvicorn with live reload
+exec uvicorn --reload --host $HOST --port $PORT --log-level $LOG_LEVEL "$APP_MODULE"

--- a/api/start.sh
+++ b/api/start.sh
@@ -1,0 +1,34 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+if [ -f /app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/gunicorn_conf.py
+elif [ -f /app/app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/app/gunicorn_conf.py
+else
+    DEFAULT_GUNICORN_CONF=/gunicorn_conf.py
+fi
+export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
+export WORKER_CLASS=${WORKER_CLASS:-"uvicorn.workers.UvicornWorker"}
+
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Gunicorn
+exec gunicorn -k "$WORKER_CLASS" -c "$GUNICORN_CONF" "$APP_MODULE"

--- a/api/text_analysis/extract_prep.py
+++ b/api/text_analysis/extract_prep.py
@@ -98,16 +98,16 @@ def predict(file=None, in_text=None, size=10, read="feather"):
     """
     if file:
         if file.filename == "":
-            return "No selected file!"
-        new_text = parse_text(file.filename)
+            raise ValueError("No selected file!")
+            in_text = parse_text(file.filename)
 
-    else:
-        # Get text from form
-        new_text = in_text
-        file = open("temp_text", "w")
-        file.write(str(new_text.encode("utf-8", "ignore")))
-        file.flush()
-        file.close()
+    # else:
+    #     # Get text from form
+    #     new_text = in_text
+    #     file = open("temp_text", "w")
+    #     file.write(str(new_text.encode("utf-8", "ignore")))
+    #     file.flush()
+    #     file.close()
     if read == "es":
         res = list(scan(es, query={}, index=idx_main))
         output_all = deque()
@@ -120,7 +120,7 @@ def predict(file=None, in_text=None, size=10, read="feather"):
 
     result = {}
     result["recommendations"] = []
-    sow = tfidftransformer.transform([new_text])
+    sow = tfidftransformer.transform([in_text])
     sow = normalize(sow, norm="l2", axis=1)
 
     # This is memory intensive.

--- a/api/text_analysis/extract_prep.py
+++ b/api/text_analysis/extract_prep.py
@@ -99,11 +99,11 @@ def predict(file=None, in_text=None, size=10, read="feather"):
     if file:
         if file.filename == "":
             raise ValueError("No selected file!")
-            in_text = parse_text(file.filename)
+        in_text = parse_text(file.filename)
 
-    # else:
-    #     # Get text from form
-    #     new_text = in_text
+    else:
+        # Get text from form
+        new_text = in_text
     #     file = open("temp_text", "w")
     #     file.write(str(new_text.encode("utf-8", "ignore")))
     #     file.flush()

--- a/api/text_analysis/extract_prep.py
+++ b/api/text_analysis/extract_prep.py
@@ -31,9 +31,9 @@ def parse_text(filepath):
     output = ""
     try:
         output = subprocess.check_output(["bash", "-c", bashCommand])
-        file = open(filepath + "_parsed.txt", "wb")
-        file.write(output)
-        file.close()
+        # file = open(filepath + "_parsed.txt", "wb")
+        # file.write(output)
+        # file.close()
     except subprocess.CalledProcessError as e:
         print(e.output)
     return str(output)

--- a/api/web_utils.py
+++ b/api/web_utils.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -12,10 +13,10 @@ def connect_to_es():
     with open("conf.yaml", "r") as stream:
         conf = yaml.safe_load(stream)
     # print(conf['es_index'][0])
-    es = Elasticsearch([conf["es_server"][0]])
-    es_index_1 = conf["es_index_main"][0]
-    es_index_2 = conf["es_index_logs"][0]
-    es_index_3 = conf["es_index_stats"][0]
+    es = Elasticsearch([os.getenv("ES_SERVER", conf["es_server"][0])])
+    es_index_1 = os.getenv("ES_INDEX_MAIN", conf["es_index_main"][0])
+    es_index_2 = os.getenv("ES_INDEX_LOGS", conf["es_index_logs"][0])
+    es_index_3 = os.getenv("ES_INDEX_STATS", conf["es_index_stats"][0])
     return es, es_index_1, es_index_2, es_index_3
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - "jointops"
     volumes:
       - "fastapi-log:/app/log"
-      - "./api/data:/api/data"
+      - "./api/data:/app/data"
     tmpfs:
       - /tmp:noexec,mode=666
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,95 @@
 version: "3.8"
+
 services:
-  fastapi:
-    container_name: fastapi
-    build:
-      context: api
-      dockerfile: Dockerfile
+  # https://www.elastic.co/guide/en/elasticsearch/reference/7.12/docker.html
+  elasticsearch:
+    container_name: &es_server elasticsearch
+    image: "docker.elastic.co/elasticsearch/elasticsearch:7.12.0"
+    cap_drop:
+      - ALL
+    cap_add:
+      - SYS_CHROOT
+      - SETGID
+      - SETUID
+      - KILL
+    environment:
+      discovery.type: "single-node"
+      node.name: *es_server
     ports:
-      - "8080:80"
+      - "9200:9200"
     networks:
       - "jointops"
     volumes:
-      - type: bind
-        source: ./api/data
-        target: /app/data
-  #      - type: volume
-  #        source: mydata
-  #        target: /container/location
+      - "elasticsearch-1-data:/usr/share/elasticsearch/data"
+      - "elasticsearch-1-logs:/usr/share/elasticsearch/logs"
+
+  # https://www.elastic.co/guide/en/kibana/7.12/docker.html
+  kibana:
+    container_name: &kibana_server kibana
+    image: "docker.elastic.co/kibana/kibana:7.12.0"
+    environment:
+      SERVER_NAME: *kibana_server
+      # ELASTICSEARCH_HOSTS: *es_server
+    cap_drop:
+      - ALL
+    ports:
+      - "5601:5601"
+    networks:
+      - "jointops"
+    depends_on:
+      - elasticsearch
+
+  # https://hub.docker.com/_/redis
+  redis:
+    container_name: &redis_server redis-1
+    image: "redis:6.2-alpine"
+    read_only: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETGID
+      - SETUID
+      - KILL
+    volumes:
+      - "redis-1-data:/data"
+    networks:
+      - "jointops"
+
+    # If data integrity is important leave the following,
+    # if not, remove it.
+    command: ["redis-server", "--appendonly", "yes"]
+
+  fastapi:
+    container_name: fastapi
+    user: &uid "1000:1000"
+    build:
+      context: api
+      dockerfile: Dockerfile
+      args:
+        uid: *uid
+    environment:
+      REDIS_SERVER: *redis_server
+      ES_SERVER: *es_server
+      ES_INDEX_MAIN: "assess_remap"
+      ES_INDEX_LOGS: "sys_logs"
+      ES_INDEX_STATS: "user_stats"
+    read_only: true
+    cap_drop:
+      - ALL
+    ports:
+      - "8080:8080"
+    networks:
+      - "jointops"
+    volumes:
+      - "fastapi-log:/app/log"
+      - "./api/data:/api/data"
+    tmpfs:
+      - /tmp:noexec,mode=666
+    depends_on:
+      - redis
+      - elasticsearch
+
+
   # !React app currently down.
   # react:
   #   container_name: react
@@ -26,31 +100,14 @@ services:
   #     - "3000:3000"
   #   networks:
   #     - "jointops"
-  elasticsearch-1:
-    container_name: elasticsearch-1
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.12.0"
-    ports:
-      - "9200:9200"
-      - "9300:9300"
-    networks:
-      - "jointops"
-  kibana:
-    container_name: kibana
-    image: "docker.elastic.co/kibana/kibana:7.12.0"
-    ports:
-      - "5601:5601"
-    networks:
-      - "jointops"
-  redis:
-    container_name: redis-1
-    image: "bitnami/redis:latest"
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-    networks:
-      - "jointops"
-    ports:
-      - "6379:6379"
+
+
 networks:
   jointops:
-# volumes:
-#   mydata:
+  
+volumes:
+  # fastapi-data:
+  fastapi-log:
+  redis-1-data:
+  elasticsearch-1-data:
+  elasticsearch-1-logs:


### PR DESCRIPTION
- Locking down the containers by restricting all and explicitly allowing kernel capabilities.
- Making containers `read_only` when base image allows (some poorly built ones do not)
  - Also explicitly defining volumes where data should be stored/mutated.
- Making sure uid is not root when we can
- Defining configuration values in environment variables
- Taking the stuff from `tiangolo/uvicorn-gunicorn-fastapi:python3.7` that makes it special and building our own image from the official python base image
- using the official redis base image
- adding tmpfs to fastapi
- removing exposed ports that didn't need to be exposed